### PR TITLE
Quiz

### DIFF
--- a/src/main/java/Problem3/Book.java
+++ b/src/main/java/Problem3/Book.java
@@ -37,11 +37,11 @@ public abstract class Book implements StoreMediaOperations {
         // The bug is caught when
         //  1. newly add tests fail while all old tests still pass
         //  2. remove the bug and use the fix below, all tests pass
-        return id.equals(theOtherBook.id) &&
+        /*return id.equals(theOtherBook.id) &&
                 author.equals(theOtherBook.author) &&
-                title.equals(theOtherBook.title);
+                title.equals(theOtherBook.title);*/
 
         // fix is here
-        // return id.equals(theOtherBook.id);
+        return id.equals(theOtherBook.id);
     }
 }

--- a/src/main/java/Problem3/BookFiction.java
+++ b/src/main/java/Problem3/BookFiction.java
@@ -17,6 +17,17 @@ public class BookFiction extends Book {
         this.genres = anotherBook.genres;
     }
 
+    //setters
+    public void setTitle(String uStr){
+        super.title = uStr;
+    }
+    public void setAuthor(String uStr){
+        super.author = uStr;
+    }
+    public void setGenres(String uStr){
+        this.genres = uStr;
+    }
+
     @Override
     public int getLateFeeInDollar() {
         return lateFeePerDayInDollar;

--- a/src/main/java/Problem3/Movie.java
+++ b/src/main/java/Problem3/Movie.java
@@ -37,11 +37,11 @@ public abstract class Movie implements StoreMediaOperations {
         // The bug is caught when
         //  1. newly add tests fail while all old tests still pass
         //  2. remove the bug and use the fix below, all tests pass
-        return id.equals(theOtherMovie.id) &&
+        /*return id.equals(theOtherMovie.id) &&
                 rating.equals(theOtherMovie.rating) &&
-                title.equals(theOtherMovie.title);
+                title.equals(theOtherMovie.title);*/
 
         // fix is here
-        //return this.id == ((Movie) obj).id;
+        return this.id == ((Movie) obj).id;
     }
 }

--- a/src/main/java/Problem3/MovieAction.java
+++ b/src/main/java/Problem3/MovieAction.java
@@ -12,6 +12,16 @@ public class MovieAction extends Movie {
         super(anotherMovie);
     }
 
+    public void setTitle(String uStr){
+        super.title = uStr;
+    }
+    public void setRating(String uStr){
+        super.rating = uStr;
+    }
+
+
+
+
     @Override
     public int getLateFeeInDollar() {
         return lateFeePerDayInDollar;

--- a/src/test/java/Problem3Test.java
+++ b/src/test/java/Problem3Test.java
@@ -7,11 +7,73 @@ public class Problem3Test {
     @Test
     public void catchTheBugInBook() {
         // quiz
+        String str0 = "test0";
+        String str1 = "test1";
+        String str2 = "test2";
+        String sBug = "bug";
+
+        BookFiction obj0 = new BookFiction(str0, str1, str2);
+        BookFiction obj1 = new BookFiction(obj0);
+
+        // obj0 and obj1 only share the same value for their ID
+        obj1.setTitle(sBug);
+
+        assertTrue(obj0.equals(obj1));
+
+        BookFiction obj2 = new BookFiction(str1, str1, str2);
+        BookFiction obj3 = new BookFiction(obj2);
+
+        obj3.setAuthor(sBug);
+
+        assertTrue(obj2.equals(obj3));
+
+        BookFiction obj4 = new BookFiction(str2, str1, str2);
+        BookFiction obj5 = new BookFiction(obj4);
+
+        obj5.setGenres(sBug);
+
+        assertTrue(obj4.equals(obj5));
+
+        BookFiction obj6 = new BookFiction(str0, str2, str2);
+        BookFiction obj7 = new BookFiction(obj6);
+
+        obj7.setTitle(sBug);
+        obj7.setGenres(sBug);
+        obj7.setAuthor(sBug);
+
+        assertTrue(obj6.equals(obj7));
+
     }
 
     @Test
     public void catchTheBugInMovie() {
         // quiz
+        String str0 = "test0";
+        String str1 = "test1";
+
+        String sBug = "bug";
+
+        MovieAction obj0 = new MovieAction(str0, str1);
+        MovieAction obj1 = new MovieAction(obj0);
+
+        obj1.setTitle(sBug);
+
+        assertTrue(obj0.equals(obj1));
+
+        MovieAction obj2 = new MovieAction(str1, str1);
+        MovieAction obj3 = new MovieAction(obj2);
+
+        obj2.setRating(sBug);
+
+        assertTrue(obj2.equals(obj3));
+
+        MovieAction obj4 = new MovieAction(str0, str1);
+        MovieAction obj5 = new MovieAction(obj4);
+
+        obj4.setTitle(sBug);
+        obj4.setRating(sBug);
+
+        assertTrue(obj4.equals(obj5));
     }
 
     // DO NOT REMOVE OR CHANGE ANYTHING BELOW THIS!


### PR DESCRIPTION
Tests can still pass with this bug in effect because the tests already written only check for cases where the variables for the randomly generated IDs are not the same, with the author, rating, or genres variables always being the same. A difference in the author, rating, or genres variables causes the equals method to return false. To correct this bug, the equals method should only check for the ID variables.